### PR TITLE
Add slides links to ES and EN

### DIFF
--- a/tutorials/EN/README.md
+++ b/tutorials/EN/README.md
@@ -23,7 +23,8 @@ Apart from tutorials, we also share other resources to go further into ML or tha
 > - Learn how to contribute and work collaboratively in your ML workflows
 >
 > **_Duration: 20-40 minutes_**
-> 👉 [click here to access the tutorial](https://www.notion.so/Workshop-A-Tour-through-the-Hugging-Face-Hub-2098e4bae9ba4288857e85c87ff1c851)
+>
+> 👉 [click here to access the tutorial](https://www.notion.so/Workshop-A-Tour-through-the-Hugging-Face-Hub-2098e4bae9ba4288857e85c87ff1c851) or 👩‍🏫 [the lecture slides](https://docs.google.com/presentation/d/1zQqpFTcpNLV7haj2Inw2qKHq8DjfZEaiObW1ZkLvPWM/edit?usp=sharing).
 
 ### 2️⃣ Build and Host Machine Learning Demos with Gradio & Hugging Face
 
@@ -36,7 +37,7 @@ Apart from tutorials, we also share other resources to go further into ML or tha
 >
 > **_Duration: 20-40 minutes_**
 >
-> 👉 [click here to access the tutorial](https://colab.research.google.com/github/huggingface/education-toolkit/blob/main/tutorials/EN/02_ml-demos-with-gradio.ipynb)
+> 👉 [click here to access the tutorial](https://colab.research.google.com/github/huggingface/education-toolkit/blob/main/tutorials/EN/02_ml-demos-with-gradio.ipynb) or 👩‍🏫 [the lecture slides](https://docs.google.com/presentation/d/14EU_xjtINXtpidWLnUvfcEpmxN46ORS-PLpwfUf8C1I/edit?usp=sharing).
 
 ### 3️⃣ Getting Started with Transformers
 

--- a/tutorials/ES/README.md
+++ b/tutorials/ES/README.md
@@ -21,7 +21,7 @@ Además de los tutoriales, también compartimos otros recursos para profundizar 
 >
 > **_Duración: 20-40 minutos_**
 >
-> [Un recorrido por el Hub de Hugging Face](https://github.com/huggingface/education-toolkit/tree/main/tutorials/ES/01_tour_hub_de_huggingface.md)
+> [Clic aquí para acceder al tutorial](https://github.com/huggingface/education-toolkit/tree/main/tutorials/ES/01_tour_hub_de_huggingface.md) o 👩‍🏫 [a las diapositivas (en inglés)](https://docs.google.com/presentation/d/1zQqpFTcpNLV7haj2Inw2qKHq8DjfZEaiObW1ZkLvPWM/edit?usp=sharing).
 
 ### **2️⃣ Cree y aloje demos de Machine Learning con Gradio y Hugging Face**
 
@@ -34,7 +34,7 @@ Además de los tutoriales, también compartimos otros recursos para profundizar 
 >
 > **_Duración: 20-40 minutos_**
 >
-> 👉 [Clic aquí para acceder al tutorial](https://colab.research.google.com/github/huggingface/education-toolkit/blob/main/tutorials/ES/02_ml-demos-con-gradio.ipynb)
+> 👉 [Clic aquí para acceder al tutorial](https://colab.research.google.com/github/huggingface/education-toolkit/blob/main/tutorials/ES/02_ml-demos-con-gradio.ipynb) o 👩‍🏫 [a las diapositivas (en inglés)](https://docs.google.com/presentation/d/14EU_xjtINXtpidWLnUvfcEpmxN46ORS-PLpwfUf8C1I/edit?usp=sharing).
 
 ### **3️⃣ Primeros pasos con los Transformers**
 


### PR DESCRIPTION
## Description

Add the same links provided by Abubakar in previous PR #10. 

Applied for both Spanish and English folders. In the case of the Spanish ones I declared: '`...o 👩‍🏫 a las diapositivas (en inglés).`' So that it is clear that the slides are in English.